### PR TITLE
feat: Add new app domain setup

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -8,7 +8,7 @@ const config: Config = {
   favicon: 'img/logo.svg',
 
   // Set the production url of your site here
-  url: 'https://docs.swiftpay.raisa.com.np',
+  url: 'https://docs.pay.raisa.com.np',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/',


### PR DESCRIPTION
Updated domain from `doc.swiftpay.com.np` to `doc.pay.raisa.com.np`. This change reflects the rebranding and transition to the new domain for better alignment with SwiftPay's services and improved user experience.